### PR TITLE
Fix MarkerArray publishing in bc-fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-recast_ros/src/recastnavigation/


### PR DESCRIPTION
Fixes compilation - cannot pass a `std::vector<Marker>` to `ros::Publisher<MarkerArray>`